### PR TITLE
added overflow hidden on jumbotron container to prevent horizontal scrolling

### DIFF
--- a/components/jumbotron/index.tsx
+++ b/components/jumbotron/index.tsx
@@ -53,6 +53,7 @@ const Jumbotron = (props: JumboTronProps) => {
         backgroundPosition: "bottom",
         backgroundSize: "cover",
         backgroundRepeat: "no-repeat",
+        overflow: "hidden",
       }}
     >
       <div className={styles.middleDisplay}>


### PR DESCRIPTION
I think this is only noticable on the "Committees and Cabinets" page, the screenshot below shows the culprit (added a red border on the <body> to show where the edge of the screen should be.

<img width="467" alt="Screenshot 2023-07-21 at 20 03 09" src="https://github.com/Model-UN/cimun-web/assets/9121099/3be492d0-0ffa-4b0d-8f7a-74ccab36b976">

I thought about putting "overflow: hidden" on the ComponentWrapper but saw it was being used all over the place and didn't want to do a full regression test on the site. 
