### PR TITLE
Remove MUNDO

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ the volunteer-run CIMUN Department of Technology.
 Chicago International Model United Nations (CIMUN) is an annual inter-scholastic
 (high school) Model UN conference in Chicago, IL. Our focus is to create realistic
 educational opportunities for young leaders in the scholastic MUN community.
-We are organized by the Model United Nations Development Organization (MUNDO).
 
 This project is the first iteration of hopefully many projects from the CIMUN
 engineering team to provide future conference organizers with the tools necessary

--- a/components/articles/about.tsx
+++ b/components/articles/about.tsx
@@ -41,13 +41,11 @@ const About = () => {
         align="justify"
         size="1.5rem"
       >
-        The <strong>Model United Nations Development Organization</strong>{" "}
-        (MUNDO) is an independent educational organization that has been
-        producing high quality, simulation-driven Model UN programs since 2003
-        in both Chicago and Mexico City. We seek to help students build their
-        understanding of global politics through realistic, fast-paced
-        experiential education programs that promote critical thinking and
-        leadership development.
+        The team behind CIMUN has been producing high quality, simulation-driven
+        Model UN programs since 2003 in both Chicago and Mexico City. We seek to
+        help students build their understanding of global politics through
+        realistic, fast-paced experiential education programs that promote
+        critical thinking and leadership development.
         <br />
         <br />
       </Body>

--- a/components/articles/kiera-king.tsx
+++ b/components/articles/kiera-king.tsx
@@ -73,7 +73,7 @@ const KieraKingAwardDetails = () => {
         receive the Kiera King Award.
         <br />
         <br />
-        Yours in MUNDO,
+        Yours in MUN,
         <br />
         Masha Polupan, Chief of Staff
       </Body>

--- a/components/stepped-form/example-data.json
+++ b/components/stepped-form/example-data.json
@@ -272,7 +272,7 @@
           "sectionId": 1,
           "required": true,
           "fieldType": "SELECTION",
-          "content": "Have you ever staffed a MUNDO conference before, if so how many?",
+          "content": "Have you ever staffed a CIMUN or MIMUN conference before, if so how many?",
           "description": "",
           "values": [
             {


### PR DESCRIPTION
We are encouraged to remove mentions of MUNDO from the site as they no longer organize the conference.