### PR TITLE
Added next config and added styledComponents compiler option

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  compiler: {
+    // Enables the styled-components SWC transform
+    styledComponents: true,
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
found a thing - https://nextjs.org/docs/architecture/nextjs-compiler#styled-components

seems to fix this error I was seeing in the dev server (wasn't happening in prod)
<img width="645" alt="Screenshot 2023-08-28 at 18 55 45" src="https://github.com/Model-UN/cimun-web/assets/9121099/c8cac9f4-8782-4ef2-9a81-1db32e4e5616">

