### PR TITLE
mobile nav, ui fixes and a11y updates

### DIFF
--- a/components/headerNav/headerNav.styles.ts
+++ b/components/headerNav/headerNav.styles.ts
@@ -4,12 +4,18 @@ import { colors } from "../../styles/colors";
 import { breakpoints } from "../../styles/breakpoints";
 
 export const HeaderWrapper = styled(ComponentWrapper)`
-  height: 3.9375vw;
-  min-height: 45px;
-  max-height: 7vh;
+  height: 60px;
   margin: auto;
   flex-direction: row;
   justify-content: space-between;
+`;
+
+export const DesktopNav = styled.div`
+  display: block;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 export const ListContainer = styled.ul`
@@ -20,12 +26,9 @@ export const ListContainer = styled.ul`
   list-style-type: none;
   margin: 0;
   padding: 0;
-  @media screen and (max-width: 900px) {
-    display: none;
-  }
 `;
 
-export const BurgerListContainer = styled.ul`
+export const MobileNavContainer = styled.div`
   display: none;
   position: absolute;
   z-index: 10;
@@ -33,15 +36,11 @@ export const BurgerListContainer = styled.ul`
   left: 0;
   background-color: ${colors.primaryBlue};
   width: 100%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  list-style-type: none;
   margin: 0;
-  padding: 2vh 2vh;
+  padding: 46px 16px 16px;
 
   ${breakpoints("display", "", [
-  { 900: "flex" }
+  { 768: "block" }
 ])};
 `;
 
@@ -59,6 +58,12 @@ export const ListItem = styled.li`
   }
 `;
 
+export const BurgerUnorderedList = styled.ul`
+  margin: 0 auto;
+  width: 70%;
+  padding: 0;
+`
+
 export const BurgerListItem = styled.li`
   display: flex;
   height: 5vh;
@@ -67,22 +72,18 @@ export const BurgerListItem = styled.li`
   align-items: center;
   justify-content: center;
   transition: all 0.2s;
+  border-bottom: 1px solid white;
 
   &:hover {
     background-color: ${colors.fadedPrimaryBlue};
     cursor: pointer;
   }
+
+  &:last-child {
+    border: none;
+  }
 `;
 
-export const BurgerSeparator = styled.hr`
-  display: flex;
-  size: 1px;
-  width: 70%;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: white;
-`;
 
 export const Anchor = styled.a`
   display: flex;
@@ -105,7 +106,7 @@ export const Anchor = styled.a`
   { 450: "0.9rem" },
 ])};
   ${breakpoints("color", "", [
-  { 900: "white" }
+  { 768: "white" }
 ])};
   text-decoration: none;
   svg {
@@ -119,8 +120,6 @@ export const LogoWrapper = styled.div`
   height: 100%;
   display: flex;
   align-items: center;
-
-  ${breakpoints("width", "", [{ 900: "100%" }])}
 `;
 
 export const Logo = styled.img`
@@ -142,17 +141,14 @@ export const BurgerLogo = styled.img`
 
 export const Burger = styled.button`
   display: none;
-  @media screen and (max-width: 900px) {
-    height: 2rem;
-    ${breakpoints("height", "px", [{ 550: 35 }, { 300: 30 }])};
-    display: flex;
-    position: absolute;
-    right: 3vw;
+  @media screen and (max-width: 768px) {
+    height: 44px;
+    width: 44px;
+    display: block;
     z-index: 10;
-    align-items: center;
-    justify-content: center;
     background: none;
     border: none;
+    padding: 0.375rem;
   }
 
   &:hover {

--- a/components/headerNav/index.tsx
+++ b/components/headerNav/index.tsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   HeaderWrapper,
   ListContainer,
-  BurgerListContainer,
+  DesktopNav,
+  MobileNavContainer,
   ListItem,
+  BurgerUnorderedList,
   BurgerListItem,
-  BurgerSeparator,
   Anchor,
   LogoWrapper,
-  Logo,
   BurgerLogo,
   Burger,
 } from "./headerNav.styles";
@@ -20,120 +19,148 @@ import {
 const HeaderNav = () => {
   const [burgerOpen, setBurgerOpen] = useState(false);
 
-  const pathname = usePathname();
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
+  // Click outside logic
   useEffect(() => {
-    if (burgerOpen) {
-      setBurgerOpen(false);
-    }
-  }, [pathname]);
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setBurgerOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   return (
-    <HeaderWrapper>
-      <LogoWrapper>
-        <Link href="/" aria-label="CIMUN Home">
-          <Image height={32} width={32} alt="" src="/cimun-logo.png" />
-        </Link>
-      </LogoWrapper>
-      {/* Desktop Nav */}
-      <nav aria-label="Main">
-        <ListContainer>
-          <ListItem>
-            <Link href="/" passHref legacyBehavior>
-              <Anchor>Home</Anchor>
-            </Link>
-          </ListItem>
-          <ListItem>
-            <Link href="/about" passHref legacyBehavior>
-              <Anchor>About</Anchor>
-            </Link>
-          </ListItem>
-          <ListItem>
-            <Link href="/committees" passHref legacyBehavior>
-              <Anchor>Committees & Cabinets</Anchor>
-            </Link>
-          </ListItem>
-          {/* <Link href="/resources">
+    <nav aria-label="main">
+      <HeaderWrapper>
+        <LogoWrapper>
+          <Link href="/" aria-label="CIMUN Home">
+            <Image height={44} width={44} alt="" src="/cimun-logo.png" />
+          </Link>
+        </LogoWrapper>
+        {/* Desktop Nav */}
+        <DesktopNav aria-label="Main">
+          <ListContainer>
+            <ListItem>
+              <Link href="/" passHref legacyBehavior>
+                <Anchor>Home</Anchor>
+              </Link>
+            </ListItem>
+            <ListItem>
+              <Link href="/about" passHref legacyBehavior>
+                <Anchor>About</Anchor>
+              </Link>
+            </ListItem>
+            <ListItem>
+              <Link href="/committees" passHref legacyBehavior>
+                <Anchor>Committees & Cabinets</Anchor>
+              </Link>
+            </ListItem>
+            {/* <Link href="/resources">
           <ListItem>
             <Anchor>Delegate Resources</Anchor>
           </ListItem>
         </Link> */}
-          {/* <Link href="https://press.cimun.org/">
+            {/* <Link href="https://press.cimun.org/">
           <ListItem>
             <Anchor>The CIMUN Chronicle</Anchor>
           </ListItem>
         </Link> */}
-          <ListItem>
-            <Link href="/school-registration" passHref legacyBehavior>
-              <Anchor>Register</Anchor>
-            </Link>
-          </ListItem>
-          <ListItem>
-            <Link href="/staff-app" passHref legacyBehavior>
-              <Anchor>Staff CIMUN XX</Anchor>
-            </Link>
-          </ListItem>
-        </ListContainer>
-      </nav>
-      {/* Mobile Nav */}
-      {burgerOpen && (
-        <nav aria-label="Main">
-          <BurgerListContainer>
-            <LogoWrapper>
-              <BurgerLogo src="/White_CIMUN_Logo.png" />
-            </LogoWrapper>
-            <BurgerListItem>
-              <Link href="/" passHref legacyBehavior>
-                <Anchor>Home</Anchor>
-              </Link>
-            </BurgerListItem>
-            <BurgerSeparator />
-            <BurgerListItem>
-              <Link href="/about" passHref legacyBehavior>
-                <Anchor>About</Anchor>
-              </Link>
-            </BurgerListItem>
-            <BurgerSeparator />
-            <BurgerListItem>
-              <Link href="/committees" passHref legacyBehavior>
-                <Anchor>Committees & Cabinets</Anchor>
-              </Link>
-            </BurgerListItem>
-            <BurgerSeparator />
-            {/* <Link href="/resources"> */}
-            {/*  <BurgerListItem> */}
-            {/*    <Anchor>Delegate Resources</Anchor> */}
-            {/*  </BurgerListItem> */}
-            {/* </Link> */}
-            {/* <BurgerSeparator /> */}
-            {/* <Link href="https://press.cimun.org/"> */}
-            {/*  <BurgerListItem> */}
-            {/*    <Anchor>The CIMUN Chronicle</Anchor> */}
-            {/*  </BurgerListItem> */}
-            {/* </Link> */}
-            <BurgerSeparator />
-            <BurgerListItem>
+            <ListItem>
               <Link href="/school-registration" passHref legacyBehavior>
                 <Anchor>Register</Anchor>
               </Link>
-            </BurgerListItem>
-            <BurgerSeparator />
-            <BurgerListItem>
+            </ListItem>
+            <ListItem>
               <Link href="/staff-app" passHref legacyBehavior>
-                <Anchor>STAFF CIMUN XX</Anchor>
+                <Anchor>Staff CIMUN XX</Anchor>
               </Link>
-            </BurgerListItem>
-          </BurgerListContainer>
-        </nav>
-      )}
-      <Burger onClick={() => setBurgerOpen(!burgerOpen)}>
-        {!burgerOpen ? (
-          <FontAwesomeIcon icon="bars" />
-        ) : (
-          <FontAwesomeIcon icon="times" color="white" />
+            </ListItem>
+          </ListContainer>
+        </DesktopNav>
+
+        <Burger
+          onClick={() => setBurgerOpen(true)}
+          id="burger"
+          aria-label="open menu"
+          aria-haspopup="true"
+          aria-expanded={burgerOpen ? "true" : "false"}
+          aria-controls="mobile-nav"
+        >
+          <FontAwesomeIcon icon="bars" color="black" />
+        </Burger>
+        {/* Mobile Nav */}
+        {burgerOpen && (
+          <MobileNavContainer
+            ref={dropdownRef}
+            id="mobile-nav"
+            role="menu"
+            aria-labelledby="burger"
+          >
+            <HeaderWrapper>
+              <LogoWrapper>
+                <BurgerLogo src="/White_CIMUN_Logo.png" alt="" />
+              </LogoWrapper>
+              <Burger
+                autoFocus
+                onClick={() => setBurgerOpen(false)}
+                aria-label="close menu"
+              >
+                <FontAwesomeIcon icon="times" color="white" />
+              </Burger>
+            </HeaderWrapper>
+            <BurgerUnorderedList>
+              <BurgerListItem>
+                <Link href="/" passHref legacyBehavior>
+                  <Anchor onClick={() => setBurgerOpen(false)}>Home</Anchor>
+                </Link>
+              </BurgerListItem>
+              <BurgerListItem>
+                <Link href="/about" passHref legacyBehavior>
+                  <Anchor onClick={() => setBurgerOpen(false)}>About</Anchor>
+                </Link>
+              </BurgerListItem>
+              <BurgerListItem>
+                <Link href="/committees" passHref legacyBehavior>
+                  <Anchor onClick={() => setBurgerOpen(false)}>
+                    Committees & Cabinets
+                  </Anchor>
+                </Link>
+              </BurgerListItem>
+              {/* <Link href="/resources"> */}
+              {/*  <BurgerListItem> */}
+              {/*    <Anchor>Delegate Resources</Anchor> */}
+              {/*  </BurgerListItem> */}
+              {/* </Link> */}
+              {/* <BurgerSeparator /> */}
+              {/* <Link href="https://press.cimun.org/"> */}
+              {/*  <BurgerListItem> */}
+              {/*    <Anchor>The CIMUN Chronicle</Anchor> */}
+              {/*  </BurgerListItem> */}
+              {/* </Link> */}
+              <BurgerListItem>
+                <Link href="/school-registration" passHref legacyBehavior>
+                  <Anchor onClick={() => setBurgerOpen(false)}>Register</Anchor>
+                </Link>
+              </BurgerListItem>
+              <BurgerListItem>
+                <Link href="/staff-app" passHref legacyBehavior>
+                  <Anchor onClick={() => setBurgerOpen(false)}>
+                    STAFF CIMUN XX
+                  </Anchor>
+                </Link>
+              </BurgerListItem>
+            </BurgerUnorderedList>
+          </MobileNavContainer>
         )}
-      </Burger>
-    </HeaderWrapper>
+      </HeaderWrapper>
+    </nav>
   );
 };
 

--- a/pages/layout.tsx
+++ b/pages/layout.tsx
@@ -8,7 +8,7 @@ const Layout = ({ children }: PropsWithChildren) => {
     <>
       <Announce.RegistrationOpen></Announce.RegistrationOpen>
       <HeaderNav />
-      {children}
+      <main>{children}</main>
       <Footer />
     </>
   );


### PR DESCRIPTION
UI fixes
- fixed hamburger button and close button not being right aligned (see image below)
- set hamburger icon color to black (was showing as blue)
- ![IMG_6233](https://github.com/Model-UN/cimun-web/assets/9121099/dcc8f1cd-d2f0-4ec9-b004-3f47685eced2)

UX
- allow user to tap off the nav to close it

A11Y improvements:
- added aria attributes to open/close buttons and nav container
- increased clickable aria on open/close buttons to 44x44 pixels to meet a11y minimums
